### PR TITLE
fix and update q1_02

### DIFF
--- a/Chap_1_Arrays_and_Strings/Q1_02_Solution2_Check_Permutation.rb
+++ b/Chap_1_Arrays_and_Strings/Q1_02_Solution2_Check_Permutation.rb
@@ -1,18 +1,8 @@
 def check_permutation_solution2(s1="", s2="")
-		letters = []
-		if s1.length == s2.length
-			letters = s1.split('')
-		
-			s2.split('').each do |char|
-				if letters.include?(char) != true
-					false
-				else 
-					s2 = s2.delete(char)
-				end
-			end
-			
-			return true if s2 == ""
-		else
-			false
-		end
+	return false if s1.length != s2.length
+	letters = Array.new(128, 0)
+
+	s1.chars{ |char| letters[char.ord] += 1 }
+	s2.chars{|char| return false if (letters[char.ord] -= 1) < 0 }
+	true
 end

--- a/Chap_1_Arrays_and_Strings/array_and_string_spec/Q1_02_Check_Permutation2_Spec.rb
+++ b/Chap_1_Arrays_and_Strings/array_and_string_spec/Q1_02_Check_Permutation2_Spec.rb
@@ -7,20 +7,20 @@ describe 'check if two words are permutations of each other' do
 	let(:horse) {'horse'}
 
 	it 'should true for being a permutation' do
-		expect(check_permutation(lemon, melon)).to eq(true)
+		expect(check_permutation_solution2(lemon, melon)).to eq(true)
 	end
 
 
 	it 'should true for being a permutation' do
-		expect(check_permutation(melon, lemon)).to eq(true)
+		expect(check_permutation_solution2(melon, lemon)).to eq(true)
 	end
 
 
 	it 'should false for not being a permutation' do
-		expect(check_permutation(jason, horse)).to eq(false)
+		expect(check_permutation_solution2(jason, horse)).to eq(false)
 	end
 
 	it 'can handle no input' do
-		expect(check_permutation()).to eq(true)
+		expect(check_permutation_solution2()).to eq(true)
 	end
 end


### PR DESCRIPTION
The current solution is inefficient due to using `include?` on every check instead of relying on array indexing. Additionally there is no need to split a string to iterate over the chars. This pr also now passes the specs.