### PR TITLE
improve Q1_01 efficiency and Ruby idiom

### DIFF
--- a/Chap_1_Arrays_and_Strings/Q1_01_Is_Unique.rb
+++ b/Chap_1_Arrays_and_Strings/Q1_01_Is_Unique.rb
@@ -1,9 +1,11 @@
-def is_unique(string)
-	unique = ""
-	string.chars do |char|
-		if unique.include?(char) == false
-			unique << char
-		end
-	end
-	string.length == unique.length ? true : false
+def is_unique?(string)
+  string.each_char.with_object({}) do |char, hash_table|
+    if hash_table[char]
+      return false
+    else
+      hash_table[char] = true
+    end
+  end
+
+  true
 end

--- a/Chap_1_Arrays_and_Strings/array_and_string_spec/Q1_01_Is_Unique_Spec.rb
+++ b/Chap_1_Arrays_and_Strings/array_and_string_spec/Q1_01_Is_Unique_Spec.rb
@@ -1,24 +1,24 @@
 require_relative('../Q1_01_Is_Unique')
 
 describe 'detects if characters are unique in a word' do
-	let(:word1) {"jason"}
-	let(:word2) {"banana"}
-	let(:word3) {"cool"}
-	let(:word4) {"cat"}
+  let(:word1) {"jason"}
+  let(:word2) {"banana"}
+  let(:word3) {"cool"}
+  let(:word4) {"cat"}
 
-	it 'Should return true, since nothing repeats' do
-		expect(is_unique(word1)).to eq(true)
-	end
+  it 'Should return true, since nothing repeats' do
+    expect(is_unique?(word1)).to eq(true)
+  end
 
-	it 'Should return true, since nothing repeats' do
-		expect(is_unique(word4)).to eq(true)
-	end
+  it 'Should return true, since nothing repeats' do
+    expect(is_unique?(word4)).to eq(true)
+  end
 
-	it 'Should return false, since there repeating characters' do
-		expect(is_unique(word2)).to eq(false)
-	end
+  it 'Should return false, since there repeating characters' do
+    expect(is_unique?(word2)).to eq(false)
+  end
 
-	it 'Should return false, since there repeating characters' do
-		expect(is_unique(word3)).to eq(false)
-	end
+  it 'Should return false, since there repeating characters' do
+    expect(is_unique?(word3)).to eq(false)
+  end
 end


### PR DESCRIPTION
The answer currently posted for Q1_01 works but could be improved in a
few ways. This PR accomplishes the following:

1) makes the algorithm more efficient by using a hash table rather than
Ruby's `String#include?`, which ends up being a loop inside of a loop,
so O(n) instead of O(n^2). It also more closely mirrors the solution in
the book.

2) improves Ruby idiom by:
  - indenting 2 spaces instead of 4
  - ending a predicate method with a question mark
  - using Ruby's `Enumerable#each_with_object` pattern and avoiding
    certain bits of extraneous code in the prior version