### PR TITLE
Add spec to account for zero edits away

### DIFF
--- a/Chap_1_Arrays_and_Strings/array_and_string_spec/Q1_05_One_Away_Spec.rb
+++ b/Chap_1_Arrays_and_Strings/array_and_string_spec/Q1_05_One_Away_Spec.rb
@@ -18,6 +18,10 @@ describe 'Checks if two words are one edit away' do
 		expect(one_away(cake, bake)).to eq(true)
 	end
 
+	it 'it will return true if 0 edits away' do
+		expect(one_away(pale, pale)).to eq(true)
+	end
+
 	it 'it will return false due to over 1 edit away' do
 		expect(one_away(cat, dog)).to eq(false)
 	end


### PR DESCRIPTION
The instructions specify that if two strings are one edit **(or zero edits)** away from each other, the function should return true. Added a spec to ensure that two identical strings return true when compared to each other.